### PR TITLE
Avoid Y2K38 problem on timestamp values

### DIFF
--- a/src/main/java/com/chargebee/internal/Resource.java
+++ b/src/main/java/com/chargebee/internal/Resource.java
@@ -140,7 +140,7 @@ public class Resource<T> {
     }
 
     public Timestamp optTimestamp(String key) {
-        Integer unxTime = optional(key, Integer.class);
+        Long unxTime = optLong(key);
         return (unxTime != null)? new Timestamp(unxTime * 1000l) : null;
     }
 


### PR DESCRIPTION
I got this problem today, because of running an estimate request today on a subscription with 10 years duration and a follower with 10 years duration (2018-01-19 + 20yeasrs => 2038).