### PR TITLE
Request and RequestBase, added get methods required for middleware vertx framework

### DIFF
--- a/src/main/java/com/chargebee/internal/Request.java
+++ b/src/main/java/com/chargebee/internal/Request.java
@@ -52,5 +52,8 @@ public class Request<U extends Request> extends RequestBase<U>{
     public Params params() {
         return params;
     }
-    
+
+    public HttpUtil.Method httpMeth() {
+        return httpMeth;
+    }
 }

--- a/src/main/java/com/chargebee/internal/RequestBase.java
+++ b/src/main/java/com/chargebee/internal/RequestBase.java
@@ -22,6 +22,12 @@ public class RequestBase<U extends RequestBase> {
         headers.put(headerName, headerValue);
         return (U)this;
     }
-    
 
+    public String uri() {
+        return uri;
+    }
+
+    public Map<String, String> headers() {
+        return headers;
+    }
 }


### PR DESCRIPTION
In middleware, using vertx we have written a framework. Where we use vertx low level client to make the request but we use chargebee java lib for pojo objects and operations, and at client level we use the request object for the data like uri, headers and data.

The changes are related to that, the methods are written weren't accessible so written few get methods.