### PR TITLE
add Automatic-Module-Name for JPMS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,18 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.chargebee.client</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.2.1</version>
                 <executions>


### PR DESCRIPTION
this is an interim step until the project targets minimum JDK versions above 8. Then a _module-info.java_ should be used. Until then specifying a _Automatic-Module-Name_ of **com.chargebee.client** is a useful first step. Please add proper support for JPMS (via a _module-info.java_) in a future release