### PR TITLE
Releasing v3.36.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+### v3.36.1 (2025-09-16) 
+* * * 
+
+### Deprecated Attribute: 
+* The `message` field has been made private in APIException, as it has long been deprecated.
+* Users should use the `getMessage()` method instead, as documented in the comments.
+
+### New Exception
+* New `APIException` `UbbBatchIngestionInvalidRequestException` has been added. 
+
 ### v3.36.0 (2025-08-19) 
 * * * 
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.chargebee</groupId>
     <artifactId>chargebee-java</artifactId>
-    <version>3.36.0</version>
+    <version>3.36.1</version>
 
 
     <packaging>jar</packaging>

--- a/src/main/java/com/chargebee/APIException.java
+++ b/src/main/java/com/chargebee/APIException.java
@@ -33,10 +33,8 @@ public class APIException extends RuntimeException {
     public final String code;
     /**
      * Use {@link #getMessage()} instead.
-     * @deprecated
      */
-    @Deprecated
-    public final String message;
+    private final String message;
     
 
     public APIException(int httpStatusCode, String message, JSONObject jsonObj) {

--- a/src/main/java/com/chargebee/Environment.java
+++ b/src/main/java/com/chargebee/Environment.java
@@ -38,7 +38,7 @@ public class Environment {
 
     public static final String API_VERSION = "v2";
     
-    public static final String LIBRARY_VERSION = "3.36.0";
+    public static final String LIBRARY_VERSION = "3.36.1";
 
     private final String apiBaseUrl;
 


### PR DESCRIPTION
### v3.36.1 (2025-09-16) 
* * * 

### Deprecated Attribute: 
* The `message` field has been made private in APIException, as it has long been deprecated.
* Users should use the `getMessage()` method instead, as documented in the comments.

### New Exception
* New `APIException` `UbbBatchIngestionInvalidRequestException` has been added. 